### PR TITLE
Remove targetSdkVersion from manifest.

### DIFF
--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -4,7 +4,6 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="10"
-        android:targetSdkVersion="19" />
+        android:minSdkVersion="10" />
 
 </manifest>


### PR DESCRIPTION
High targetSdkVersion breaks gradle compatibility with other libraries. (E.g. Roboelectric that does not support API 19).

I see no reason for restricting people targeting a lower sdk, as long it's above the minimum requirement.
