### PR TITLE
Add @Unique annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,10 @@ API
 - `@PrimaryKey` Used to mark a field as a primary key. Multiple primary keys in a class are allowed and will result in a composite primary key.
 - `@ForeignKey` Used to mark a field as a foreign key. The argument given to this annotation should be in the form of `"foreignKeyTable(foreignKeyColumn)"`.
 - `@CascadeDelete` Used to mark a field which is also marked as a foreign key as a cascade deleting field.
+- `@Unique` Used to mark a field which should be unique in the database. Optionally, a conflict clause can be specified in the form of `@Unique(ConflictClause.FAIL)`.
 
 ###Saving
-The save method is both an insert and an update method, the correct thing will be done depending on the model existance in the database. The first two methods below are syncronous, the second is for using together with a transaction (more on that later). There are also two asyncronous methods, one with a callback and one without. The syncronous methods will return a boolean indicating if the model was saved or not. The asyncronous method with a callback will just not invoke the callback if saving failed.
+The save method is both an insert and an update method, the correct operation will be done depending on the model's existence in the database. The first two methods below are synchronous, the second is for use together with a transaction (more on that later). There are also two asynchronous methods, one with a callback and one without. The synchronous methods will return a boolean indicating if the model was saved or not. The asynchronous method with a callback will just not invoke the callback if saving failed.
 ```java
 boolean save();
 boolean save(Transaction t);
@@ -128,7 +129,7 @@ Once the query has been started you can get the result with two different method
 boolean getAsync(LoaderManager lm, ResultHandler<? extends Model> handler, Class<? extends Model>... respondsToUpdatedOf);
 ```
 
-`get()` returns either the `QueryResult` or a list of the `QueryResult` represented by the `Class` you sent in as the first argument to the query method. `getAsync()` is the same only that the result is delivered on a callback function after executing `get()` on another thread. `getAsync()` also delivers updated results once the backing model of the query is updated if you return `true` indicating you want firther updates. `getAsync()` uses loaders and therefore needs a `LoaderManager` instance. `getAsync()` also takes an optional array of classes which is used when the query relies on more models than the one you are querying for and you want the query to be updated when those models change as well.
+`get()` returns either the `QueryResult` or a list of the `QueryResult` represented by the `Class` you sent in as the first argument to the query method. `getAsync()` is the same only that the result is delivered on a callback function after executing `get()` on another thread. `getAsync()` also delivers updated results once the backing model of the query is updated if you return `true` indicating you want further updates. `getAsync()` uses loaders and therefore needs a `LoaderManager` instance. `getAsync()` also takes an optional array of classes which is used when the query relies on more models than the one you are querying for and you want the query to be updated when those models change as well.
 
 ###CursorList
 All Queries return a `CursorList` subclass. This is a `Iterable` subclass which lazily unpacks a cursor into its corresponding model when you ask for the next item. This leads to having the efficiency of a `Cursor` but without the pain. Excluding the `Iterable` methods `CursorList` also provides the following methods.

--- a/library/src/main/java/se/emilsjolander/sprinkles/ColumnField.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/ColumnField.java
@@ -2,19 +2,23 @@ package se.emilsjolander.sprinkles;
 
 import java.lang.reflect.Field;
 
+import se.emilsjolander.sprinkles.annotations.ConflictClause;
+
 class ColumnField {
 
 	String name;
 	String type;
 	String foreignKey;
+	ConflictClause uniqueConflictClause;
 	
 	boolean isPrimaryKey;
 	boolean isForeignKey;
 	boolean isAutoIncrementPrimaryKey;
 	boolean isCascadeDelete;
-	
+	boolean isUnique;
+
 	public Field field;
-	
+
 	@Override
 	public boolean equals(Object o) {
 		if (o instanceof ColumnField) {

--- a/library/src/main/java/se/emilsjolander/sprinkles/DbOpenHelper.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/DbOpenHelper.java
@@ -11,10 +11,12 @@ class DbOpenHelper extends SQLiteOpenHelper {
 				Sprinkles.sInstance.mMigrations.size());
 	}
 
+	@Override
 	public void onCreate(SQLiteDatabase db) {
 		executeMigrations(db, 0, Sprinkles.sInstance.mMigrations.size());
 	}
 
+	@Override
 	public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
 		executeMigrations(db, oldVersion, newVersion);
 	}

--- a/library/src/main/java/se/emilsjolander/sprinkles/Utils.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/Utils.java
@@ -18,6 +18,7 @@ import se.emilsjolander.sprinkles.annotations.DynamicColumn;
 import se.emilsjolander.sprinkles.annotations.ForeignKey;
 import se.emilsjolander.sprinkles.annotations.PrimaryKey;
 import se.emilsjolander.sprinkles.annotations.Table;
+import se.emilsjolander.sprinkles.annotations.Unique;
 import se.emilsjolander.sprinkles.exceptions.AutoIncrementMustBeIntegerException;
 import se.emilsjolander.sprinkles.exceptions.CannotCascadeDeleteNonForeignKey;
 import se.emilsjolander.sprinkles.exceptions.DuplicateColumnException;
@@ -129,6 +130,7 @@ class Utils {
 				column.isForeignKey = field.isAnnotationPresent(ForeignKey.class);
 				column.isPrimaryKey = field.isAnnotationPresent(PrimaryKey.class);
 				column.isCascadeDelete = field.isAnnotationPresent(CascadeDelete.class);
+				column.isUnique = field.isAnnotationPresent(Unique.class);
 
 				if (column.isForeignKey) {
 					column.foreignKey = field.getAnnotation(ForeignKey.class).value();
@@ -144,6 +146,10 @@ class Utils {
 				
 				if (column.isAutoIncrementPrimaryKey && (column.isPrimaryKey || column.isForeignKey)) {
 					throw new IllegalStateException("A @AutoIncrementPrimaryKey field may not also be an @PrimaryKey or @ForeignKey field");
+				}
+
+				if (column.isUnique) {
+					column.uniqueConflictClause = field.getAnnotation(Unique.class).value();
 				}
 
 				column.field = field;

--- a/library/src/main/java/se/emilsjolander/sprinkles/annotations/ConflictClause.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/annotations/ConflictClause.java
@@ -1,0 +1,56 @@
+package se.emilsjolander.sprinkles.annotations;
+
+/**
+ * Specifies how Sprinkle should handle conflicts using SQLite ON CONFLICT clauses.
+ *
+ * @see http://www.sqlite.org/lang_conflict.html
+ */
+public enum ConflictClause {
+	/**
+	 * When an applicable constraint violation occurs, the ROLLBACK resolution algorithm aborts
+	 * the current SQL statement with an SQLITE_CONSTRAINT error and rolls back the current
+	 * transaction. If no transaction is active (other than the implied transaction that is
+	 * created on every command) then the ROLLBACK resolution algorithm works the same as the
+	 * ABORT algorithm.
+	 */
+	ROLLBACK,
+	/**
+	 * When an applicable constraint violation occurs, the ABORT resolution algorithm aborts the
+	 * current SQL statement with an SQLITE_CONSTRAINT error and backs out any changes made by
+	 * the current SQL statement; but changes caused by prior SQL statements within the same
+	 * transaction are preserved and the transaction remains active. This is the default behavior
+	 * and the behavior specified by the SQL standard.
+	 */
+	ABORT,
+	/**
+	 * When an applicable constraint violation occurs, the FAIL resolution algorithm aborts the
+	 * current SQL statement with an SQLITE_CONSTRAINT error. But the FAIL resolution does not
+	 * back out prior changes of the SQL statement that failed nor does it end the transaction.
+	 * For example, if an UPDATE statement encountered a constraint violation on the 100th row
+	 * that it attempts to update, then the first 99 row changes are preserved but changes to
+	 * rows 100 and beyond never occur.
+	 */
+	FAIL,
+	/**
+	 * When an applicable constraint violation occurs, the IGNORE resolution algorithm skips the
+	 * one row that contains the constraint violation and continues processing subsequent rows of
+	 * the SQL statement as if nothing went wrong. Other rows before and after the row that
+	 * contained the constraint violation are inserted or updated normally. No error is returned
+	 * when the IGNORE conflict resolution algorithm is used.
+	 */
+	IGNORE,
+	/**
+	 * When a UNIQUE constraint violation occurs, the REPLACE algorithm deletes pre-existing rows
+	 * that are causing the constraint violation prior to inserting or updating the current row
+	 * and the command continues executing normally. If a NOT NULL constraint violation occurs,
+	 * the REPLACE conflict resolution replaces the NULL value with the default value for that
+	 * column, or if the column has no default value, then the ABORT algorithm is used. If a
+	 * CHECK constraint violation occurs, the REPLACE conflict resolution algorithm always works
+	 * like ABORT.
+	 */
+	REPLACE,
+	/**
+	 * Performs the default operation of the database by not specifying a ON CONFLICT clause.
+	 */
+	DEFAULT
+}

--- a/library/src/main/java/se/emilsjolander/sprinkles/annotations/Unique.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/annotations/Unique.java
@@ -1,0 +1,21 @@
+package se.emilsjolander.sprinkles.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Adds an UNIQUE modifier to the underlying database column. To specify a conflict-clause,
+ * include it as a {@link ConflictClause} in the parentheses. For
+ * example, {@code
+ *
+ * @Unique(ConflictClause.ROLLBACK) private String name;
+ * }. If no {@code ConflictClause} is specified, the default behavior will be used.
+ * @see http://www.sqlite.org/syntaxdiagrams.html#conflict-clause
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Unique {
+	ConflictClause value() default ConflictClause.DEFAULT;
+}

--- a/library/src/test/java/se/emilsjolander/sprinkles/annotations/UniqueTest.java
+++ b/library/src/test/java/se/emilsjolander/sprinkles/annotations/UniqueTest.java
@@ -1,0 +1,20 @@
+package se.emilsjolander.sprinkles.annotations;
+
+import android.test.AndroidTestCase;
+
+import se.emilsjolander.sprinkles.Migration;
+import se.emilsjolander.sprinkles.Sprinkles;
+import se.emilsjolander.sprinkles.models.UniqueTestModel;
+
+public class UniqueTest extends AndroidTestCase {
+
+	public void testUniqueAnnotationIsEnforced() {
+
+		Sprinkles sprinkles = Sprinkles.getInstance(getContext());
+		sprinkles.addMigration(new Migration().createTable(UniqueTestModel.class));
+
+		assertTrue(new UniqueTestModel().setName("testName").save());
+		assertTrue(new UniqueTestModel().setName("testName2").save());
+		assertFalse(new UniqueTestModel().setName("testName").save());
+	}
+}

--- a/library/src/test/java/se/emilsjolander/sprinkles/models/UniqueTestModel.java
+++ b/library/src/test/java/se/emilsjolander/sprinkles/models/UniqueTestModel.java
@@ -1,0 +1,21 @@
+package se.emilsjolander.sprinkles.models;
+
+import se.emilsjolander.sprinkles.TestModel;
+import se.emilsjolander.sprinkles.annotations.Table;
+import se.emilsjolander.sprinkles.annotations.Unique;
+
+@Table("UniqueTestModel")
+public class UniqueTestModel extends TestModel {
+
+	@Unique
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public UniqueTestModel setName(String name) {
+		this.name = name;
+		return this;
+	}
+}


### PR DESCRIPTION
This annotation will specify that a column is to be unique and as such
can be used as a candidate key. As written, this annotation can be
combined with any other annotations.

There is a provided test which fails as written since it relies on an
actual database.

The annotation can be used as follows:

``` java
public class MyModel extends Model {
    @Unique
    private String name;

    @Unique(ConflictClause.FAIL)
    private String email;
}
```
