### PR TITLE
Changed type parameter of CursorIterator to extend QueryResult instead of Model

### DIFF
--- a/library/src/main/java/se/emilsjolander/sprinkles/CursorIterator.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/CursorIterator.java
@@ -4,7 +4,7 @@ import android.database.Cursor;
 
 import java.util.Iterator;
 
-class CursorIterator<T extends Model> implements Iterator<T> {
+class CursorIterator<T extends QueryResult> implements Iterator<T> {
 
     private Cursor cursor;
     private Class<T> type;

--- a/library/src/main/java/se/emilsjolander/sprinkles/CursorList.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/CursorList.java
@@ -62,7 +62,7 @@ public class CursorList<T extends QueryResult> implements Iterable<T>, Closeable
 
     @Override
     public Iterator<T> iterator() {
-        return new CursorIterator(cursor, type);
+        return new CursorIterator<T>(cursor, type);
     }
 
     /**


### PR DESCRIPTION
There is no reason for CursorIterator to require its elements to extend Model instead of QueryResult, because Utils::getResultFromCursor() works with QueryResults too.

This fixes an unchecked cast and I think an error that would have been thrown if you tried to use a CursorList of QueryResults with a for...in loop (or called CursorList::asList() for example).
