### PR TITLE
Implicit table and column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ public class Note extends Model {
 	public long getId() {
 		return id;
 	}
-	
+
 }
 ```
 Ok, a lot of important stuff in this short class. First of all, a model must subclass `se.emilsjolander.sprinkles.Model` and it also must have a `@Table` annotations specifying the table name that the model corresponds to. After the class declaration we have declared three members: `id`, `title` and `body`. Notice how all of them have a `@Column` annotation to mark that they are not only a member of this class but also a column of the table that this class represents. We have one last annotation in the above example. The `@AutoIncrementPrimaryKey`, this annotation tells sprinkles that the field is both an autoincrement field and a primary key field. A field with this annotation will automatically be set upon the creation of its corresponding row in the table.
@@ -46,13 +46,13 @@ Ok, a lot of important stuff in this short class. First of all, a model must sub
 Before using this class you must migrate it into the database. I recommend doing this in the `onCreate()` method of an `Application` subclass like this:
 ```java
 public class MyApplication extends Application {
-	
+
 	@Override
 	public void onCreate() {
 		super.onCreate();
-		
+
 		Sprinkles sprinkles = Sprinkles.getInstance(getApplicationContext());
-		
+
 		Migration initialMigration = new Migration();
 		initialMigration.createTable(Note.class);
 		sprinkles.addMigration(initialMigration);
@@ -83,10 +83,10 @@ There is a lot more you can do with sprinkles so please read the next section wh
 API
 ---
 ###Annotations
-- `@Table` Used to associate a model class with a SQL table.
+- `@Table` Used to associate a model class with a SQL table. It receives the table name as an optional argument. If no table name is explicitly set, the class name will be used.
 - `@AutoIncrementPrimaryKey` Used to mark a field as an auto-incrementing primary key. The field must be an `int` or a `long` and cannot be in the same class as any other primary key.
-- `@Column` Used to associate a class field with a SQL column.
-- `@DynamicColumn` Used to associate a class field with a dynamic SQL column such as an alias in a query.
+- `@Column` Used to associate a class field with a SQL column. It receives the column name as an optional argument. If no column name is explicitly set, the field name will be used.
+- `@DynamicColumn` Used to associate a class field with a dynamic SQL column such as an alias in a query. It receives the column name as an optional argument. If no column name is explicitly set, the field name will be used.
 - `@PrimaryKey` Used to mark a field as a primary key. Multiple primary keys in a class are allowed and will result in a composite primary key.
 - `@ForeignKey` Used to mark a field as a foreign key. The argument given to this annotation should be in the form of `"foreignKeyTable(foreignKeyColumn)"`.
 - `@CascadeDelete` Used to mark a field which is also marked as a foreign key as a cascade deleting field.
@@ -140,7 +140,7 @@ All Queries return a `CursorList` subclass. This is a `Iterable` subclass which 
 public int size();
 public T get(int pos);
 public List<T> asList();
-``` 
+```
 Remember to always call `close()` on a `CursorList` instance! This will close the underlying cursor.
 
 ###Transactions
@@ -200,13 +200,13 @@ protected void afterDelete() {
 Migrations are the way you add things to your database. I suggest putting all your migrations in the `onCreate()` method of a `Application` subclass. Here is a quick example of how that would look:
 ```java
 public class MyApplication extends Application {
-	
+
 	@Override
 	public void onCreate() {
 		super.onCreate();
-		
+
 		Sprinkles sprinkles = Sprinkles.getInstance(getApplicationContext());
-		
+
 		Migration initialMigration = new Migration();
 		initialMigration.createTable(Note.class);
 		sprinkles.addMigration(initialMigration);
@@ -229,4 +229,3 @@ Through an instance of `Sprinkles` you can register your own `TypeSerializer` in
 
 ###Relationships
 Sprinkles does nothing to handle relationships for you; this is by design. You will have to use the regular ways to handle relationships in SQL. Sprinkles gives you all the tools needed for this and it works very well.
-

--- a/library/src/main/java/se/emilsjolander/sprinkles/Migration.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/Migration.java
@@ -36,7 +36,7 @@ public class Migration {
 		final StringBuilder createStatement = new StringBuilder();
 
 		createStatement.append("CREATE TABLE ");
-		createStatement.append(info.tableName);
+        createStatement.append(info.tableName);
 		createStatement.append("(");
 
         // only list primary keys in the end if they exists and there is not only one that is autoincrement.
@@ -46,8 +46,9 @@ public class Migration {
 
 		for (int i = 0; i < info.staticColumns.size(); i++) {
 			final ModelInfo.StaticColumnField column = info.staticColumns.get(i);
-			createStatement.append(column.name + " ");
-			createStatement.append(column.sqlType);
+			createStatement.append(column.name);
+            createStatement.append(" ");
+            createStatement.append(column.sqlType);
 
 			if (column.isAutoIncrement && column.isPrimaryKey) {
 				createStatement.append(" PRIMARY KEY AUTOINCREMENT");
@@ -63,7 +64,9 @@ public class Migration {
                 createStatement.append(" NOT NULL");
             }
             if (column.hasCheck) {
-                createStatement.append(" CHECK("+column.checkClause+")");
+                createStatement.append(" CHECK(");
+                createStatement.append(column.checkClause);
+                createStatement.append(")");
             }
 
 			// add a comma separator between columns if it is not the last column
@@ -128,7 +131,7 @@ public class Migration {
 	 * @return this Migration instance
 	 */
 	public Migration dropTable(Class<? extends Model> clazz) {
-		final String tableName = Utils.getTableName(clazz);
+		final String tableName = ModelInfo.from(clazz).tableName;
 		mStatements.add(String.format("DROP TABLE IF EXISTS %s;", tableName));
 		return this;
 	}

--- a/library/src/main/java/se/emilsjolander/sprinkles/Model.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/Model.java
@@ -60,7 +60,7 @@ public abstract class Model implements QueryResult {
 		final Model m = Query.one(
 				getClass(),
 				String.format("SELECT * FROM %s WHERE %s LIMIT 1",
-						Utils.getTableName(getClass()),
+                        ModelInfo.from(getClass()).tableName,
 						Utils.getWhereStatement(this))).get();
 		return m != null;
 	}
@@ -97,21 +97,22 @@ public abstract class Model implements QueryResult {
 			return false;
 		}
 
+        final ModelInfo info = ModelInfo.from(getClass());
+
         beforeSave();
         if (exists()) {
-            if (t.update(Utils.getTableName(getClass()),
+            if (t.update(info.tableName,
                     Utils.getContentValues(this), Utils.getWhereStatement(this)) == 0) {
                 return false;
             }
         } else {
             beforeCreate();
-            long id = t.insert(Utils.getTableName(getClass()), Utils.getContentValues(this));
+            long id = t.insert(info.tableName, Utils.getContentValues(this));
             if (id == -1) {
                 return false;
             }
 
             // set the @AutoIncrement column if one exists
-            final ModelInfo info = ModelInfo.from(getClass());
             if (info.autoIncrementColumn != null) {
                 info.autoIncrementColumn.field.setAccessible(true);
                 try {
@@ -183,7 +184,7 @@ public abstract class Model implements QueryResult {
      *      The transaction to delete this model in
      */
 	final public void delete(Transaction t) {
-		t.delete(Utils.getTableName(getClass()), Utils.getWhereStatement(this));
+		t.delete(ModelInfo.from(getClass()).tableName, Utils.getWhereStatement(this));
         t.addOnTransactionCommittedListener(new OnTransactionCommittedListener() {
 
             @Override

--- a/library/src/main/java/se/emilsjolander/sprinkles/ModelInfo.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/ModelInfo.java
@@ -170,9 +170,11 @@ class ModelInfo {
     }
 
     private static <T extends Model> String getTableName(Class<T> clazz) {
-        if (clazz.isAnnotationPresent(Table.class)) {
-            return clazz.getAnnotation(Table.class).value();
+        if (!clazz.isAnnotationPresent(Table.class)) {
+            throw new NoTableAnnotationException();
         }
-        throw new NoTableAnnotationException();
+
+        String name = clazz.getAnnotation(Table.class).value().trim();
+        return name.isEmpty() ? clazz.getSimpleName() : name;
     }
 }

--- a/library/src/main/java/se/emilsjolander/sprinkles/ModelInfo.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/ModelInfo.java
@@ -94,7 +94,7 @@ class ModelInfo {
         for (Field field : fields) {
             if (field.isAnnotationPresent(DynamicColumn.class)) {
                 DynamicColumnField column = new DynamicColumnField();
-                column.name = field.getAnnotation(DynamicColumn.class).value();
+                column.name = getDynamicColumnName(field);
                 column.sqlType = Sprinkles.sInstance.typeSerializers.get(field.getType()).getSqlType().name();
                 column.field = field;
                 info.dynamicColumns.add(column);
@@ -104,7 +104,7 @@ class ModelInfo {
 
             } else if (field.isAnnotationPresent(Column.class)) {
                 StaticColumnField column = new StaticColumnField();
-                column.name = field.getAnnotation(Column.class).value();
+                column.name = getColumnName(field);
 
                 column.isAutoIncrement = field.isAnnotationPresent(AutoIncrementPrimaryKey.class);
                 column.isForeignKey = field.isAnnotationPresent(ForeignKey.class);
@@ -176,5 +176,15 @@ class ModelInfo {
 
         String name = clazz.getAnnotation(Table.class).value().trim();
         return name.isEmpty() ? clazz.getSimpleName() : name;
+    }
+
+    private static String getColumnName(Field field) {
+        String name = field.getAnnotation(Column.class).value().trim();
+        return name.isEmpty() ? field.getName() : name;
+    }
+
+    private static String getDynamicColumnName(Field field) {
+        String name = field.getAnnotation(DynamicColumn.class).value().trim();
+        return name.isEmpty() ? field.getName() : name;
     }
 }

--- a/library/src/main/java/se/emilsjolander/sprinkles/ModelInfo.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/ModelInfo.java
@@ -17,12 +17,14 @@ import se.emilsjolander.sprinkles.annotations.DynamicColumn;
 import se.emilsjolander.sprinkles.annotations.ForeignKey;
 import se.emilsjolander.sprinkles.annotations.NotNull;
 import se.emilsjolander.sprinkles.annotations.PrimaryKey;
+import se.emilsjolander.sprinkles.annotations.Table;
 import se.emilsjolander.sprinkles.annotations.Unique;
 import se.emilsjolander.sprinkles.exceptions.AutoIncrementMustBeIntegerException;
 import se.emilsjolander.sprinkles.exceptions.CannotCascadeDeleteNonForeignKey;
 import se.emilsjolander.sprinkles.exceptions.DuplicateColumnException;
 import se.emilsjolander.sprinkles.exceptions.EmptyTableException;
 import se.emilsjolander.sprinkles.exceptions.NoPrimaryKeysException;
+import se.emilsjolander.sprinkles.exceptions.NoTableAnnotationException;
 import se.emilsjolander.sprinkles.typeserializers.SqlType;
 
 class ModelInfo {
@@ -154,7 +156,7 @@ class ModelInfo {
             throw new EmptyTableException(clazz.getName());
         }
         if (Model.class.isAssignableFrom(clazz)) {
-            info.tableName = Utils.getTableName((Class<? extends Model>) clazz);
+            info.tableName = getTableName((Class<? extends Model>) clazz);
             if (info.primaryKeys.size() == 0) {
                 throw new NoPrimaryKeysException();
             }
@@ -167,4 +169,10 @@ class ModelInfo {
         return info;
     }
 
+    private static <T extends Model> String getTableName(Class<T> clazz) {
+        if (clazz.isAnnotationPresent(Table.class)) {
+            return clazz.getAnnotation(Table.class).value();
+        }
+        throw new NoTableAnnotationException();
+    }
 }

--- a/library/src/main/java/se/emilsjolander/sprinkles/Query.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/Query.java
@@ -72,6 +72,6 @@ public final class Query {
      * @return the query to execute
      */
     public static <T extends Model> ManyQuery<T> all(Class<T> clazz) {
-        return many(clazz, "SELECT * FROM " + Utils.getTableName(clazz));
+        return many(clazz, "SELECT * FROM " + ModelInfo.from(clazz).tableName);
     }
 }

--- a/library/src/main/java/se/emilsjolander/sprinkles/Utils.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/Utils.java
@@ -10,11 +10,8 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 
-import se.emilsjolander.sprinkles.annotations.Table;
-import se.emilsjolander.sprinkles.exceptions.NoTableAnnotationException;
-
 class Utils {
-	
+
 	static <T extends QueryResult> T getResultFromCursor(Class<T> resultClass, Cursor c) {
 		try {
             final ModelInfo info = ModelInfo.from(resultClass);
@@ -34,7 +31,7 @@ class Utils {
 			throw new RuntimeException(e);
 		}
 	}
-	
+
 	static String getWhereStatement(Model m) {
         final ModelInfo info = ModelInfo.from(m.getClass());
 		final StringBuilder where = new StringBuilder();
@@ -64,7 +61,7 @@ class Utils {
 	static ContentValues getContentValues(Model model) {
 		final ModelInfo info = ModelInfo.from(model.getClass());
 		final ContentValues values = new ContentValues();
-		
+
 		for (ModelInfo.StaticColumnField column : info.staticColumns) {
 			if (column.isAutoIncrement) {
 				continue;
@@ -80,19 +77,12 @@ class Utils {
                 Sprinkles.sInstance.typeSerializers.get(value.getClass()).pack(value, values, column.name);
 			}
 		}
-		
+
 		return values;
 	}
 
     static <T extends Model> Uri getNotificationUri(Class<T> clazz) {
-        return Uri.parse("sprinkles://"+getTableName(clazz));
-    }
-
-    static String getTableName(Class<? extends Model> clazz) {
-        if (clazz.isAnnotationPresent(Table.class)) {
-            return clazz.getAnnotation(Table.class).value();
-        }
-        throw new NoTableAnnotationException();
+        return Uri.parse("sprinkles://" + ModelInfo.from(clazz).tableName);
     }
 
     static String insertSqlArgs(String sql, Object[] args) {

--- a/library/src/main/java/se/emilsjolander/sprinkles/annotations/Column.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/annotations/Column.java
@@ -11,5 +11,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Column {
-	String value();
+	String value() default "";
 }

--- a/library/src/main/java/se/emilsjolander/sprinkles/annotations/DynamicColumn.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/annotations/DynamicColumn.java
@@ -11,5 +11,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DynamicColumn {
-	String value();
+	String value() default "";
 }

--- a/library/src/main/java/se/emilsjolander/sprinkles/annotations/Table.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/annotations/Table.java
@@ -11,5 +11,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Table {
-	String value();
+	String value() default "";
 }

--- a/library/src/test/java/se/emilsjolander/sprinkles/ModelInfoTest.java
+++ b/library/src/test/java/se/emilsjolander/sprinkles/ModelInfoTest.java
@@ -7,6 +7,7 @@ import org.robolectric.annotation.Config;
 
 import se.emilsjolander.sprinkles.annotations.AutoIncrementPrimaryKey;
 import se.emilsjolander.sprinkles.annotations.Column;
+import se.emilsjolander.sprinkles.annotations.DynamicColumn;
 import se.emilsjolander.sprinkles.annotations.Table;
 import se.emilsjolander.sprinkles.exceptions.NoTableAnnotationException;
 
@@ -24,7 +25,13 @@ public class ModelInfoTest {
     }
 
     @Table
-    public static class DefaultTableNameTestModel extends AbsTestModel {
+    public static class DefaultNamesTestModel extends AbsTestModel {
+
+        @Column
+        private String title;
+
+        @DynamicColumn
+        private int count;
     }
 
     @Table("Tests")
@@ -77,9 +84,14 @@ public class ModelInfoTest {
     }
 
     @Test
-    public void getDefaultTableName() {
-        ModelInfo info = ModelInfo.from(DefaultTableNameTestModel.class);
-        assertEquals(info.tableName, "DefaultTableNameTestModel");
+    public void defaultNames() {
+        ModelInfo info = ModelInfo.from(DefaultNamesTestModel.class);
+        assertEquals(info.tableName, "DefaultNamesTestModel");
+        assertEquals(info.columns.size(), 3);
+        assertEquals(info.staticColumns.size(), 2);
+        assertEquals(info.staticColumns.get(0).name, "title");
+        assertEquals(info.dynamicColumns.size(), 1);
+        assertEquals(info.dynamicColumns.get(0).name, "count");
     }
 
     @Test

--- a/library/src/test/java/se/emilsjolander/sprinkles/ModelInfoTest.java
+++ b/library/src/test/java/se/emilsjolander/sprinkles/ModelInfoTest.java
@@ -23,6 +23,10 @@ public class ModelInfoTest {
         @Column("id") private long id;
     }
 
+    @Table
+    public static class DefaultTableNameTestModel extends AbsTestModel {
+    }
+
     @Table("Tests")
     public static class TestModel extends AbsTestModel {
 
@@ -70,6 +74,12 @@ public class ModelInfoTest {
     @Test(expected = NoTableAnnotationException.class)
     public void getTableNameNoAnnotation() {
         ModelInfo.from(AbsTestModel.class);
+    }
+
+    @Test
+    public void getDefaultTableName() {
+        ModelInfo info = ModelInfo.from(DefaultTableNameTestModel.class);
+        assertEquals(info.tableName, "DefaultTableNameTestModel");
     }
 
     @Test

--- a/library/src/test/java/se/emilsjolander/sprinkles/ModelInfoTest.java
+++ b/library/src/test/java/se/emilsjolander/sprinkles/ModelInfoTest.java
@@ -8,7 +8,7 @@ import org.robolectric.annotation.Config;
 import se.emilsjolander.sprinkles.annotations.AutoIncrementPrimaryKey;
 import se.emilsjolander.sprinkles.annotations.Column;
 import se.emilsjolander.sprinkles.annotations.Table;
-import se.emilsjolander.sprinkles.annotations.Unique;
+import se.emilsjolander.sprinkles.exceptions.NoTableAnnotationException;
 
 import static junit.framework.Assert.*;
 import static se.emilsjolander.sprinkles.ModelInfo.ColumnField;
@@ -17,11 +17,14 @@ import static se.emilsjolander.sprinkles.ModelInfo.ColumnField;
 @RunWith(RobolectricTestRunner.class)
 public class ModelInfoTest {
 
-    @Table("Tests")
-    public static class TestModel extends Model {
+    public static class AbsTestModel extends Model {
 
         @AutoIncrementPrimaryKey
         @Column("id") private long id;
+    }
+
+    @Table("Tests")
+    public static class TestModel extends AbsTestModel {
 
         @Column("title")
         private String title;
@@ -62,6 +65,11 @@ public class ModelInfoTest {
         assertEquals(info.dynamicColumns.size(), 0);
         assertEquals(info.primaryKeys.size(), 1);
         assertEquals(info.foreignKeys.size(), 0);
+    }
+
+    @Test(expected = NoTableAnnotationException.class)
+    public void getTableNameNoAnnotation() {
+        ModelInfo.from(AbsTestModel.class);
     }
 
     @Test

--- a/library/src/test/java/se/emilsjolander/sprinkles/UtilsTest.java
+++ b/library/src/test/java/se/emilsjolander/sprinkles/UtilsTest.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import se.emilsjolander.sprinkles.annotations.AutoIncrementPrimaryKey;
 import se.emilsjolander.sprinkles.annotations.Column;
 import se.emilsjolander.sprinkles.annotations.Table;
-import se.emilsjolander.sprinkles.exceptions.NoTableAnnotationException;
 
 import static junit.framework.Assert.*;
 
@@ -36,7 +35,6 @@ public class UtilsTest {
         public void setId(long id) {
             this.id = id;
         }
-
     }
 
     @Table("Tests")
@@ -93,16 +91,6 @@ public class UtilsTest {
     public void getNotificationUri() {
         String result = Utils.getNotificationUri(TestModel.class).toString();
         assertTrue(result.contains("Tests"));
-    }
-
-    @Test
-    public void getTableName() {
-        assertEquals(Utils.getTableName(TestModel.class), "Tests");
-    }
-
-    @Test(expected = NoTableAnnotationException.class)
-    public void getTableNameNoAnnotation() {
-        Utils.getTableName(AbsTestModel.class);
     }
 
     @Test


### PR DESCRIPTION
Often the field name and column name are the same, so it's not needed to define it explicitly. Thats why I changed the argument of the `@Column` and `@DynamicColumn` annotations to be optional. If it isn't set, the SQL column name will be the same as the model's field name.

For the `@Table` annotation I've done the same, so if you don't explicitly define a table name, the class name of the model will be used.

We could also add some (optional) inflection to automatically translate class/field names to table/column names e.g. from _createdAt_ to _created_at_ (with an interface, so that users could create their own naming strategies, of course). But maybe thats too much magic...
