### PR TITLE
Reintroduce ModelList for mass model save/delete actions

### DIFF
--- a/library/src/main/java/se/emilsjolander/sprinkles/ModelList.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/ModelList.java
@@ -1,0 +1,113 @@
+package se.emilsjolander.sprinkles;
+
+import android.os.AsyncTask;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ModelList<E extends Model> extends ArrayList<E> {
+
+    private static final long serialVersionUID = 9111033070491580889L;
+
+    public interface OnAllSavedCallback {
+        void onAllSaved();
+    }
+
+    public interface OnAllDeletedCallback {
+        void onAllDeleted();
+    }
+
+    public static <E extends Model> ModelList<E> from(CursorList<E> cursorList) {
+        return (ModelList<E>) cursorList.asList();
+    }
+
+    public ModelList() {
+        super();
+    }
+
+    public ModelList(int capacity) {
+        super(capacity);
+    }
+
+    public ModelList(Collection<? extends E> collection) {
+        super(collection);
+    }
+
+    public boolean saveAll() {
+        Transaction t = new Transaction();
+        try {
+            t.setSuccessful(saveAll(t));
+        } finally {
+            t.finish();
+        }
+
+        return t.isSuccessful();
+    }
+
+    public boolean saveAll(Transaction t) {
+        for (Model m : this) {
+            if (!m.save(t)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public void saveAllAsync() {
+        saveAllAsync(null);
+    }
+
+    public void saveAllAsync(final OnAllSavedCallback callback) {
+        new AsyncTask<Void, Void, Boolean>() {
+
+            protected Boolean doInBackground(Void... params) {
+                return saveAll();
+            }
+
+            protected void onPostExecute(Boolean result) {
+                if (result && callback != null) {
+                    callback.onAllSaved();
+                }
+            }
+
+        }.execute();
+    }
+
+    public void deleteAll() {
+        Transaction t = new Transaction();
+        try {
+            deleteAll(t);
+            t.setSuccessful(true);
+        } finally {
+            t.finish();
+        }
+    }
+
+    public void deleteAll(Transaction t) {
+        for (Model m : this) {
+            m.delete(t);
+        }
+    }
+
+    public void deleteAllAsync() {
+        deleteAllAsync(null);
+    }
+
+    public void deleteAllAsync(final OnAllDeletedCallback callback) {
+        new AsyncTask<Void, Void, Void>() {
+
+            protected Void doInBackground(Void... params) {
+                deleteAll();
+                return null;
+            }
+
+            protected void onPostExecute(Void result) {
+                if (callback != null) {
+                    callback.onAllDeleted();
+                }
+            }
+
+        }.execute();
+    }
+}

--- a/library/src/main/java/se/emilsjolander/sprinkles/ModelList.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/ModelList.java
@@ -18,7 +18,7 @@ public class ModelList<E extends Model> extends ArrayList<E> {
     }
 
     public static <E extends Model> ModelList<E> from(CursorList<E> cursorList) {
-        return (ModelList<E>) cursorList.asList();
+        return new ModelList<E>(cursorList.asList());
     }
 
     public ModelList() {

--- a/library/src/test/java/se/emilsjolander/sprinkles/ModelListTest.java
+++ b/library/src/test/java/se/emilsjolander/sprinkles/ModelListTest.java
@@ -1,0 +1,152 @@
+package se.emilsjolander.sprinkles;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import android.database.MatrixCursor;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import se.emilsjolander.sprinkles.annotations.AutoIncrementPrimaryKey;
+import se.emilsjolander.sprinkles.annotations.Column;
+import se.emilsjolander.sprinkles.annotations.Table;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+@Config(emulateSdk = 18)
+@RunWith(RobolectricTestRunner.class)
+public class ModelListTest {
+
+    @Table("Tests")
+    public static class TestModel extends Model {
+
+        @AutoIncrementPrimaryKey
+        @Column("id") private long id;
+
+        @Column("title") private String title;
+
+        public long getId() {
+            return id;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+    }
+
+    @Before
+    public void initTables() {
+        Sprinkles.dropInstances();
+        Sprinkles sprinkles = Sprinkles.getInstance(Robolectric.application);
+        sprinkles.addMigration(new Migration().createTable(TestModel.class));
+    }
+
+    @Test
+    public void fromCursorList() {
+        MatrixCursor c = new MatrixCursor(new String[]{"title", "id"});
+        c.addRow(new Object[]{"title1", 1});
+        c.addRow(new Object[]{"title2", 2});
+        c.addRow(new Object[]{"title3", 3});
+        CursorList<TestModel> cursorList = new CursorList<TestModel>(c, TestModel.class);
+
+        ModelList<TestModel> modelList = ModelList.from(cursorList);
+        assertEquals(3, modelList.size());
+        assertEquals("title1", modelList.get(0).getTitle());
+        assertEquals("title2", modelList.get(1).getTitle());
+        assertEquals("title3", modelList.get(2).getTitle());
+    }
+
+    @Test
+    public void saveAllModels() {
+        TestModel m1 = new TestModel();
+        m1.setTitle("foo");
+        TestModel m2 = new TestModel();
+        m2.setTitle("bar");
+
+        ModelList<Model> modelList = new ModelList<Model>();
+        modelList.add(m1);
+        modelList.add(m2);
+
+        assertTrue(modelList.saveAll());
+        assertTrue(m1.exists());
+        assertTrue(m2.exists());
+    }
+
+    @Test
+    public void saveAllModelsAsync() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        TestModel m1 = new TestModel();
+        m1.setTitle("foo");
+        TestModel m2 = new TestModel();
+        m2.setTitle("bar");
+
+        ModelList<Model> modelList = new ModelList<Model>();
+        modelList.add(m1);
+        modelList.add(m2);
+
+        modelList.saveAllAsync(new ModelList.OnAllSavedCallback() {
+            @Override public void onAllSaved() {
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(30, TimeUnit.SECONDS));
+        assertTrue(m1.exists());
+        assertTrue(m2.exists());
+    }
+
+    @Test
+    public void deleteAllModels() {
+        TestModel m1 = new TestModel();
+        m1.setTitle("foo");
+        TestModel m2 = new TestModel();
+        m2.setTitle("bar");
+
+        ModelList<Model> modelList = new ModelList<Model>();
+        modelList.add(m1);
+        modelList.add(m2);
+
+        modelList.saveAll();
+        modelList.deleteAll();
+
+        assertFalse(m1.exists());
+        assertFalse(m2.exists());
+    }
+
+    @Test
+    public void deleteAllModelsAsync() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        TestModel m1 = new TestModel();
+        m1.setTitle("foo");
+        TestModel m2 = new TestModel();
+        m2.setTitle("bar");
+
+        ModelList<Model> modelList = new ModelList<Model>();
+        modelList.add(m1);
+        modelList.add(m2);
+
+        modelList.saveAll();
+        modelList.deleteAllAsync(new ModelList.OnAllDeletedCallback() {
+            @Override public void onAllDeleted() {
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(30, TimeUnit.SECONDS));
+        assertFalse(m1.exists());
+        assertFalse(m2.exists());
+    }
+}


### PR DESCRIPTION
I'm using your old ModelList class for mass save actions together with Retrofit. My Retrofit services return `ModelList<? extends Model>` types for which I then can do `service.fetchAll().saveAll();`.

I've also added the static method `from(CursorList<? extends Model> cursorList)` which returns a new ModelList from a CursorList so that you can e.g. delete all models of your query with one call.
