### PR TITLE
reuse callbacks, default table/column names, & unique combinations

### DIFF
--- a/library/src/main/java/se/emilsjolander/sprinkles/ManyQuery.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/ManyQuery.java
@@ -72,7 +72,7 @@ public final class ManyQuery<T extends QueryResult> {
             respondsToUpdatedOf = Utils.concatArrays(respondsToUpdatedOf, new Class[]{resultClass});
         }
 		final int loaderId = sqlQuery.hashCode();
-		lm.initLoader(loaderId, null,
+		lm.restartLoader(loaderId, null,
 				getLoaderCallbacks(sqlQuery, resultClass, handler, respondsToUpdatedOf));
 	}
 
@@ -97,7 +97,7 @@ public final class ManyQuery<T extends QueryResult> {
             respondsToUpdatedOf = Utils.concatArrays(respondsToUpdatedOf, new Class[]{resultClass});
         }
 		final int loaderId = sqlQuery.hashCode();
-		lm.initLoader(loaderId, null,
+		lm.restartLoader(loaderId, null,
 				getSupportLoaderCallbacks(sqlQuery, resultClass, handler, respondsToUpdatedOf));
 	}
 

--- a/library/src/main/java/se/emilsjolander/sprinkles/Migration.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/Migration.java
@@ -43,6 +43,7 @@ public class Migration {
         final boolean appendPrimaryKeys =
                 !(info.primaryKeys.isEmpty() || info.primaryKeys.size() == 1 && info.autoIncrementColumn != null);
         final boolean appendForeignKeys = !info.foreignKeys.isEmpty();
+        final boolean appendUniqueCombos = !info.uniqueCombos.isEmpty();
 
 		for (int i = 0; i < info.staticColumns.size(); i++) {
 			final ModelInfo.StaticColumnField column = info.staticColumns.get(i);
@@ -114,6 +115,21 @@ public class Migration {
 				createStatement.append(", ");
 			}
 		}
+
+        if (appendUniqueCombos) {
+            createStatement.append(", UNIQUE(");
+            for (int i = 0; i < info.uniqueCombos.size(); i++) {
+                final ModelInfo.StaticColumnField column = info.uniqueCombos.get(i);
+                createStatement.append(column.name);
+
+                // add a comma separator if there are still foreign keys to add
+                if (i < info.uniqueCombos.size() - 1) {
+                    createStatement.append(", ");
+                }
+            }
+            createStatement.append(") ON CONFLICT ");
+            createStatement.append(info.uniqueComboConflictClause);
+        }
 
 		createStatement.append(");");
 

--- a/library/src/main/java/se/emilsjolander/sprinkles/ModelInfo.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/ModelInfo.java
@@ -103,6 +103,9 @@ class ModelInfo {
             } else if (field.isAnnotationPresent(Column.class)) {
                 StaticColumnField column = new StaticColumnField();
                 column.name = field.getAnnotation(Column.class).value();
+                if("" == column.name) {
+                    column.name = field.getName().toLowerCase();
+                }
 
                 column.isAutoIncrement = field.isAnnotationPresent(AutoIncrementPrimaryKey.class);
                 column.isForeignKey = field.isAnnotationPresent(ForeignKey.class);

--- a/library/src/main/java/se/emilsjolander/sprinkles/ModelInfo.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/ModelInfo.java
@@ -18,6 +18,8 @@ import se.emilsjolander.sprinkles.annotations.ForeignKey;
 import se.emilsjolander.sprinkles.annotations.NotNull;
 import se.emilsjolander.sprinkles.annotations.PrimaryKey;
 import se.emilsjolander.sprinkles.annotations.Unique;
+import se.emilsjolander.sprinkles.annotations.UniqueCombo;
+import se.emilsjolander.sprinkles.annotations.UniqueComboConflictClause;
 import se.emilsjolander.sprinkles.exceptions.AutoIncrementMustBeIntegerException;
 import se.emilsjolander.sprinkles.exceptions.CannotCascadeDeleteNonForeignKey;
 import se.emilsjolander.sprinkles.exceptions.DuplicateColumnException;
@@ -59,6 +61,8 @@ class ModelInfo {
         boolean isUnique;
         ConflictClause uniqueConflictClause;
 
+        boolean isUniqueCombo;
+
         boolean hasCheck;
         String checkClause;
     }
@@ -70,11 +74,13 @@ class ModelInfo {
     private static Map<Class<? extends QueryResult>, ModelInfo> cache = new HashMap<Class<? extends QueryResult>, ModelInfo>();
 
     String tableName;
+    ConflictClause uniqueComboConflictClause;
     Set<ColumnField> columns = new HashSet<ColumnField>();
     List<DynamicColumnField> dynamicColumns = new ArrayList<DynamicColumnField>();
     List<StaticColumnField> staticColumns = new ArrayList<StaticColumnField>();
     List<StaticColumnField> foreignKeys = new ArrayList<StaticColumnField>();
     List<StaticColumnField> primaryKeys = new ArrayList<StaticColumnField>();
+    List<StaticColumnField> uniqueCombos = new ArrayList<StaticColumnField>();
     StaticColumnField autoIncrementColumn;
 
 
@@ -112,6 +118,7 @@ class ModelInfo {
                 column.isPrimaryKey = field.isAnnotationPresent(PrimaryKey.class) || column.isAutoIncrement;
                 column.isCascadeDelete = field.isAnnotationPresent(CascadeDelete.class);
                 column.isUnique = field.isAnnotationPresent(Unique.class);
+                column.isUniqueCombo = field.isAnnotationPresent(UniqueCombo.class);
                 column.isNotNull = field.isAnnotationPresent(NotNull.class);
                 column.hasCheck = field.isAnnotationPresent(Check.class);
 
@@ -142,6 +149,9 @@ class ModelInfo {
                 if (column.isUnique) {
                     column.uniqueConflictClause = field.getAnnotation(Unique.class).value();
                 }
+                if (column.isUniqueCombo) {
+                    info.uniqueCombos.add(column);
+                }
                 if (column.hasCheck) {
                     column.checkClause = field.getAnnotation(Check.class).value();
                 }
@@ -158,6 +168,13 @@ class ModelInfo {
         }
         if (Model.class.isAssignableFrom(clazz)) {
             info.tableName = Utils.getTableName((Class<? extends Model>) clazz);
+            if(info.uniqueCombos.size() > 0) {
+                if(clazz.isAnnotationPresent(UniqueComboConflictClause.class)) {
+                    info.uniqueComboConflictClause = clazz.getAnnotation(UniqueComboConflictClause.class).value();
+                } else {
+                    info.uniqueComboConflictClause = ConflictClause.ABORT;
+                }
+            }
             if (info.primaryKeys.size() == 0) {
                 throw new NoPrimaryKeysException();
             }

--- a/library/src/main/java/se/emilsjolander/sprinkles/OneQuery.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/OneQuery.java
@@ -80,7 +80,7 @@ public final class OneQuery<T extends QueryResult> {
             respondsToUpdatedOf = Utils.concatArrays(respondsToUpdatedOf, new Class[]{resultClass});
         }
 		final int loaderId = sqlQuery.hashCode();
-		lm.initLoader(loaderId, null,
+		lm.restartLoader(loaderId, null,
 				getLoaderCallbacks(sqlQuery, resultClass, handler, respondsToUpdatedOf));
 	}
 
@@ -104,7 +104,7 @@ public final class OneQuery<T extends QueryResult> {
             respondsToUpdatedOf = Utils.concatArrays(respondsToUpdatedOf, new Class[]{resultClass});
         }
 		final int loaderId = sqlQuery.hashCode();
-		lm.initLoader(loaderId, null,
+		lm.restartLoader(loaderId, null,
 				getSupportLoaderCallbacks(sqlQuery, resultClass, handler, respondsToUpdatedOf));
 	}
 

--- a/library/src/main/java/se/emilsjolander/sprinkles/Utils.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/Utils.java
@@ -88,7 +88,11 @@ class Utils {
 
     static String getTableName(Class<? extends Model> clazz) {
         if (clazz.isAnnotationPresent(Table.class)) {
-            return clazz.getAnnotation(Table.class).value();
+            if(""!=clazz.getAnnotation(Table.class).value()) {
+                return clazz.getAnnotation(Table.class).value();
+            } else {
+                return clazz.getSimpleName();
+            }
         }
         throw new NoTableAnnotationException();
     }

--- a/library/src/main/java/se/emilsjolander/sprinkles/annotations/Column.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/annotations/Column.java
@@ -11,5 +11,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Column {
-	String value();
+	String value() default "";
 }

--- a/library/src/main/java/se/emilsjolander/sprinkles/annotations/Table.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/annotations/Table.java
@@ -11,5 +11,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Table {
-	String value();
+	String value() default "";
 }

--- a/library/src/main/java/se/emilsjolander/sprinkles/annotations/UniqueCombo.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/annotations/UniqueCombo.java
@@ -1,0 +1,21 @@
+package se.emilsjolander.sprinkles.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Adds an UNIQUE modifier to the underlying database column. To specify a conflict-clause,
+ * include it as a {@link se.emilsjolander.sprinkles.annotations.ConflictClause} in the parentheses. For
+ * example, {@code
+ *
+ * @Unique(ConflictClause.ROLLBACK) private String name;
+ * }. If no {@code ConflictClause} is specified, the default behavior will be used.
+ * @see <a href="http://www.sqlite.org/syntaxdiagrams.html#conflict-clause">http://www.sqlite.org/syntaxdiagrams.html#conflict-clause</a>
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UniqueCombo {
+	ConflictClause value() default ConflictClause.DEFAULT;
+}

--- a/library/src/main/java/se/emilsjolander/sprinkles/annotations/UniqueComboConflictClause.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/annotations/UniqueComboConflictClause.java
@@ -1,0 +1,21 @@
+package se.emilsjolander.sprinkles.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Adds an UNIQUE modifier to the underlying database column. To specify a conflict-clause,
+ * include it as a {@link ConflictClause} in the parentheses. For
+ * example, {@code
+ *
+ * @Unique(ConflictClause.ROLLBACK) private String name;
+ * }. If no {@code ConflictClause} is specified, the default behavior will be used.
+ * @see <a href="http://www.sqlite.org/syntaxdiagrams.html#conflict-clause">http://www.sqlite.org/syntaxdiagrams.html#conflict-clause</a>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UniqueComboConflictClause {
+	ConflictClause value() default ConflictClause.DEFAULT;
+}


### PR DESCRIPTION
The library is great but to integrate it into a project I am working on I needed to add unique combinations and that I could restart the loaders to working with callbacks more than once.

While adding that I made it so that I could use the variable names and class names as the column names and table names respectively by default if no argument is given to @column or @table

I hope that you and the rest of your library's users find these modifications useful
