### PR TITLE
return the id of the loader from getAsync in ManyQuery

### DIFF
--- a/library/src/main/java/se/emilsjolander/sprinkles/ManyQuery.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/ManyQuery.java
@@ -62,10 +62,12 @@ public final class ManyQuery<T extends QueryResult> {
      *
      * @param respondsToUpdatedOf
      *      A list of models excluding the queried model that should also trigger a update to the result if they change.
+     *
+     * @return the id of the loader.
      */
 	@SuppressWarnings("unchecked")
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-    public void getAsync(LoaderManager lm,
+    public int getAsync(LoaderManager lm,
 			ResultHandler<T> handler,
 			Class<? extends Model>... respondsToUpdatedOf) {
         if (Model.class.isAssignableFrom(resultClass)) {
@@ -74,6 +76,7 @@ public final class ManyQuery<T extends QueryResult> {
 		final int loaderId = sqlQuery.hashCode();
 		lm.initLoader(loaderId, null,
 				getLoaderCallbacks(sqlQuery, resultClass, handler, respondsToUpdatedOf));
+        return loaderId;
 	}
 
 
@@ -88,9 +91,11 @@ public final class ManyQuery<T extends QueryResult> {
      *
      * @param respondsToUpdatedOf
      *      A list of models excluding the queried model that should also trigger a update to the result if they change.
+     *
+     * @return the id of the loader.
      */
     @SuppressWarnings("unchecked")
-	public void getAsync(android.support.v4.app.LoaderManager lm,
+	public int getAsync(android.support.v4.app.LoaderManager lm,
 			ResultHandler<T> handler,
 			Class<? extends Model>... respondsToUpdatedOf) {
         if (Model.class.isAssignableFrom(resultClass)) {
@@ -99,6 +104,7 @@ public final class ManyQuery<T extends QueryResult> {
 		final int loaderId = sqlQuery.hashCode();
 		lm.initLoader(loaderId, null,
 				getSupportLoaderCallbacks(sqlQuery, resultClass, handler, respondsToUpdatedOf));
+        return loaderId;
 	}
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)

--- a/library/src/main/java/se/emilsjolander/sprinkles/OneQuery.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/OneQuery.java
@@ -70,10 +70,12 @@ public final class OneQuery<T extends QueryResult> {
      *
      * @param respondsToUpdatedOf
      *      A list of models excluding the queried model that should also trigger a update to the result if they change.
+     *
+     * @return the id of the loader.
      */
     @SuppressWarnings("unchecked")
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-	public void getAsync(LoaderManager lm,
+	public int getAsync(LoaderManager lm,
 			ResultHandler<T> handler,
             Class<? extends Model>... respondsToUpdatedOf) {
         if (Model.class.isAssignableFrom(resultClass)) {
@@ -82,6 +84,7 @@ public final class OneQuery<T extends QueryResult> {
 		final int loaderId = sqlQuery.hashCode();
 		lm.initLoader(loaderId, null,
 				getLoaderCallbacks(sqlQuery, resultClass, handler, respondsToUpdatedOf));
+        return loaderId;
 	}
 
     /**
@@ -95,9 +98,11 @@ public final class OneQuery<T extends QueryResult> {
      *
      * @param respondsToUpdatedOf
      *      A list of models excluding the queried model that should also trigger a update to the result if they change.
+     *
+     * @return the id of the loader.
      */
     @SuppressWarnings("unchecked")
-	public void getAsync(android.support.v4.app.LoaderManager lm,
+	public int getAsync(android.support.v4.app.LoaderManager lm,
 			ResultHandler<T> handler,
             Class<? extends Model>... respondsToUpdatedOf) {
         if (Model.class.isAssignableFrom(resultClass)) {
@@ -106,6 +111,7 @@ public final class OneQuery<T extends QueryResult> {
 		final int loaderId = sqlQuery.hashCode();
 		lm.initLoader(loaderId, null,
 				getSupportLoaderCallbacks(sqlQuery, resultClass, handler, respondsToUpdatedOf));
+        return loaderId;
 	}
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)


### PR DESCRIPTION
return the id of the loader from getAsync in ManyQuery so the user can destroy the loader if the user chooses
