### PR TITLE
Add two methods to query sql loading from raw text file

### DIFF
--- a/library/src/main/java/se/emilsjolander/sprinkles/Query.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/Query.java
@@ -36,6 +36,30 @@ public final class Query {
 	}
 
     /**
+     * Start a query for a single instance of type T
+     *
+     * @param clazz
+     *      The class representing the type of the model you want returned
+     *
+     * @param sqlResId
+     *      The raw sql resource id that should be executed.
+     *
+     * @param sqlArgs
+     *      The array of arguments to insert instead of ? in the placeholderQuery statement.
+     *      Strings are automatically placeholderQuery escaped.
+     *
+     * @param <T>
+     *      The type of the model you want returned
+     *
+     * @return the query to execute
+     */
+    public static <T extends QueryResult> OneQuery<T> one(Class<T> clazz, int sqlResId,
+                                                          Object... sqlArgs) {
+        String sql = Utils.readRawText(sqlResId);
+        return one(clazz, sql, sqlArgs);
+    }
+
+    /**
      * Start a query for a list of instance of type T
      *
      * @param clazz
@@ -61,6 +85,30 @@ public final class Query {
 		query.rawQuery = Utils.insertSqlArgs(sql, sqlArgs);
 		return query;
 	}
+
+    /**
+     * Start a query for a list of instance of type T
+     *
+     * @param clazz
+     *      The class representing the type of the list you want returned
+     *
+     * @param sqlResId
+     *      The raw sql resource id that should be executed.
+     *
+     * @param sqlArgs
+     *      The array of arguments to insert instead of ? in the placeholderQuery statement.
+     *      Strings are automatically placeholderQuery escaped.
+     *
+     * @param <T>
+     *      The type of the list you want returned
+     *
+     * @return the query to execute
+     */
+    public static <T extends QueryResult> ManyQuery<T> many(Class<T> clazz, int sqlResId,
+                                                            Object... sqlArgs) {
+        String sql = Utils.readRawText(sqlResId);
+        return many(clazz, sql, sqlArgs);
+    }
 
     /**
      * Start a query for the entire list of instance of type T

--- a/library/src/main/java/se/emilsjolander/sprinkles/Utils.java
+++ b/library/src/main/java/se/emilsjolander/sprinkles/Utils.java
@@ -4,6 +4,10 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -132,4 +136,25 @@ class Utils {
         return result;
     }
 
+    static String readRawText(int rawId) {
+        final InputStream inputStream = Sprinkles.sInstance.mContext
+                .getResources().openRawResource(rawId);
+        final InputStreamReader inputStreamReader = new InputStreamReader(
+                inputStream);
+        final BufferedReader bufferedReader = new BufferedReader(
+                inputStreamReader);
+
+        String line;
+        final StringBuilder body = new StringBuilder();
+        try {
+            while ((line = bufferedReader.readLine()) != null)
+            {
+                body.append(line);
+                body.append('\n');
+            }
+        } catch (IOException e) {
+            return null;
+        }
+        return body.toString();
+    }
 }


### PR DESCRIPTION
I really like to write SQL by sprinkles, but I don't like to write SQL like this:

```
"select Notes.*, " +
              "(select count(*) from NoteTagLinks where NoteTagLinks.note_id = Notes.id) as tag_count " +
              "from Notes order by created_at desc"
```

So I added two methods to run SQL written in raw text files.
Just add text files(such as query_notes.sql) into raw folder, and write SQL directly in files.

I don't know how to write test case with raw files, but I tested it with sample model. It looks good.
